### PR TITLE
Fixes bower.json's invalid json syntax

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "responsive"
   ],
   "dependencies" : {
-    angular: null
+    "angular": null
   },
   "license": "Apache",
   "ignore": [


### PR DESCRIPTION
Currently `bower install` fails as the JSON in your `bower.json` is invalid.
This PR fixes that.

On a separate note -- can you clarify what you mean in the `README` when you say `Right now this works just fine if you reach a breakpoint on page load. I currently have a solution for automatically converting tabs to accordions and vice versa but I'm looking for a better solution. Stay tuned.`.
